### PR TITLE
Destroy missions fixed (88.30)

### DIFF
--- a/MMOCoreORB/bin/scripts/managers/mission/mission_manager.lua
+++ b/MMOCoreORB/bin/scripts/managers/mission/mission_manager.lua
@@ -64,10 +64,28 @@ bh_targets_at_mission_level = {
 	}
 }
 
+
 enable_factional_crafting_missions = "true"
-
 enable_factional_recon_missions = "true"
-
 enable_factional_entertainer_missions = "true"
-
 enable_same_account_bounty_missions = "false"
+
+playerBountyKillBuffer = 30 * 60 * 1000 -- Buffer before player bounty can be put back on terminal after target is killed, set 0 to disable
+playerBountyDebuffLength = 3 * 24 * 60 * 60 * 1000 -- Time before their bounty resets from the minimum amount
+
+-- Destroy Mission Configuration
+-- Distance calculated as: 
+--    <BaseDistance> + <DifficultyDistanceFactor> * <difficultyLevel> + 
+--    rand(<RandomDistance>) + rand(<DifficutlyRandomDistance * <difficultyLevel>)
+destroyMissionBaseDistance = 1000
+destroyMissionDifficultyDistanceFactor = 0
+destroyMissionRandomDistance = 1000
+destroyMissionDifficultyRandomDistance = 0
+
+-- Mission payout calculated as: 
+--    <BaseReward> + <DifficultyRewardFactor> * <difficultyLevel> + 
+--    rand(<RandomReward>) + rand(<DifficutlyRandomReward * <difficultyLevel>)
+destroyMissionBaseReward = 0
+destroyMissionDifficultyRewardFactor = 375
+destroyMissionRandomReward = 0
+destroyMissionDifficultyRandomReward = 15


### PR DESCRIPTION
Destroy missions from Terminals were fixed. File was corrupt and didn't load the variable to the missions. (88.25 to 88.30)